### PR TITLE
Implemented 3 Power-Ups Spawning with Cool Down

### DIFF
--- a/Co-Op-Snake-2D/Assets/Prefabs/Foods/Mass Gainer.prefab
+++ b/Co-Op-Snake-2D/Assets/Prefabs/Foods/Mass Gainer.prefab
@@ -117,7 +117,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.009485513, y: 0.0015809014}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -128,5 +128,5 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.5324971, y: 0.49139297}
+  m_Size: {x: 0.5, y: 0.5}
   m_EdgeRadius: 0

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps.meta
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 138a907c9665c8e408b1711dcea5af18
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Score Boost Power Up.prefab
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Score Boost Power Up.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &9019244861067251212
+--- !u!1 &4869955432590448250
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1070406103350869622}
-  - component: {fileID: 8929156585541864078}
-  - component: {fileID: 5699068049737604593}
-  m_Layer: 6
-  m_Name: Mass Burner
+  - component: {fileID: 4010627006934467843}
+  - component: {fileID: 8001700761881919440}
+  - component: {fileID: 1805565901759395474}
+  m_Layer: 7
+  m_Name: Score Boost Power Up
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1070406103350869622
+--- !u!4 &4010627006934467843
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 4869955432590448250}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8929156585541864078
+--- !u!212 &8001700761881919440
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 4869955432590448250}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -74,24 +74,24 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: -1
-  m_Sprite: {fileID: 21300000, guid: 162c961f79f03a7419bae8455ff18508, type: 3}
-  m_Color: {r: 1, g: 0.8, b: 0.6, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 37616095ebf53744c950962f33663458, type: 3}
+  m_Color: {r: 0.68235296, g: 0.8745098, b: 0.96862745, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.4, y: 0.4}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &5699068049737604593
+--- !u!61 &1805565901759395474
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 4869955432590448250}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -121,8 +121,8 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 1, y: 1}
+    oldSize: {x: 0.4, y: 0.4}
+    newSize: {x: 0.4, y: 0.4}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Score Boost Power Up.prefab.meta
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Score Boost Power Up.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0ab97b6903bcf274abd8ad26238878f2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Shield Power Up.prefab
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Shield Power Up.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &9019244861067251212
+--- !u!1 &8424945900358878291
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1070406103350869622}
-  - component: {fileID: 8929156585541864078}
-  - component: {fileID: 5699068049737604593}
-  m_Layer: 6
-  m_Name: Mass Burner
+  - component: {fileID: 8967746963226425611}
+  - component: {fileID: 411900123076237680}
+  - component: {fileID: 5654861373177150393}
+  m_Layer: 7
+  m_Name: Shield Power Up
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1070406103350869622
+--- !u!4 &8967746963226425611
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 8424945900358878291}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8929156585541864078
+--- !u!212 &411900123076237680
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 8424945900358878291}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -74,24 +74,24 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: -1
-  m_Sprite: {fileID: 21300000, guid: 162c961f79f03a7419bae8455ff18508, type: 3}
-  m_Color: {r: 1, g: 0.8, b: 0.6, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 37616095ebf53744c950962f33663458, type: 3}
+  m_Color: {r: 0.69411767, g: 0.6117647, b: 0.8509804, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.4, y: 0.4}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &5699068049737604593
+--- !u!61 &5654861373177150393
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 8424945900358878291}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -121,8 +121,8 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 1, y: 1}
+    oldSize: {x: 0.4, y: 0.4}
+    newSize: {x: 0.4, y: 0.4}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Shield Power Up.prefab.meta
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Shield Power Up.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b428e9028a177b142857e4d148c97891
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Speed Up Power Up.prefab
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Speed Up Power Up.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &9019244861067251212
+--- !u!1 &4562044704465877926
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1070406103350869622}
-  - component: {fileID: 8929156585541864078}
-  - component: {fileID: 5699068049737604593}
-  m_Layer: 6
-  m_Name: Mass Burner
+  - component: {fileID: 8101752563188745320}
+  - component: {fileID: 666979533336878045}
+  - component: {fileID: -3406312770165373630}
+  m_Layer: 7
+  m_Name: Speed Up Power Up
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1070406103350869622
+--- !u!4 &8101752563188745320
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 4562044704465877926}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8929156585541864078
+--- !u!212 &666979533336878045
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 4562044704465877926}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -74,24 +74,24 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: -1
-  m_Sprite: {fileID: 21300000, guid: 162c961f79f03a7419bae8455ff18508, type: 3}
-  m_Color: {r: 1, g: 0.8, b: 0.6, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 37616095ebf53744c950962f33663458, type: 3}
+  m_Color: {r: 1, g: 0.4117647, b: 0.38039216, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.4, y: 0.4}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &5699068049737604593
+--- !u!61 &-3406312770165373630
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9019244861067251212}
+  m_GameObject: {fileID: 4562044704465877926}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -121,8 +121,8 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 1, y: 1}
+    oldSize: {x: 0.4, y: 0.4}
+    newSize: {x: 0.4, y: 0.4}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Speed Up Power Up.prefab.meta
+++ b/Co-Op-Snake-2D/Assets/Prefabs/PowerUps/Speed Up Power Up.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b6dd36ad51e5bfe49aafd9181c699b0a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Co-Op-Snake-2D/Assets/Scenes/SingleScene.unity
+++ b/Co-Op-Snake-2D/Assets/Scenes/SingleScene.unity
@@ -425,6 +425,10 @@ MonoBehaviour:
   initialBodySize: 10
   speed: 500
   moveStep: 0.7
+  powerUpCoolDownTimer: 3
+  scoreBoostPowerUpRatio: 2
+  isShieldPowerUpActive: 0
+  speedUpPowerUpRatio: 1.5
   mainCamera: {fileID: 519420031}
   snakeHeadPrefab: {fileID: 3328811613065628134, guid: f056f978e5b80184886c318d3f4a2b6e, type: 3}
   snakeBodyPrefab: {fileID: 7558181762298159681, guid: b8db81fb33f4a7040b7f6c666c7b4cce, type: 3}
@@ -566,90 +570,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 205527295}
   m_CullTransparentMesh: 1
---- !u!1 &335436968
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 335436970}
-  - component: {fileID: 335436969}
-  m_Layer: 0
-  m_Name: Score Boost Power Up
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &335436969
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 335436968}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 37616095ebf53744c950962f33663458, type: 3}
-  m_Color: {r: 0.68235296, g: 0.8745098, b: 0.96862745, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.4, y: 0.4}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &335436970
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 335436968}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.6245916, y: -4.9661603, z: 0.106325634}
-  m_LocalScale: {x: 2, y: 2, z: 2}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2141316966}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -910,7 +830,6 @@ MonoBehaviour:
   minSpawnInterval: 3
   maxSpawnInterval: 6
   foodLifetime: 10
-  minSnakeLengthForMassBurner: 2
   foods:
   - foodType: 0
     foodPrefab: {fileID: 3543856675319177350, guid: baa2c14275340804b9ffd0b69528dab1, type: 3}
@@ -1175,90 +1094,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1172800749}
   m_CullTransparentMesh: 1
---- !u!1 &1368485747
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1368485749}
-  - component: {fileID: 1368485748}
-  m_Layer: 0
-  m_Name: Shield Power Up
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1368485748
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1368485747}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 37616095ebf53744c950962f33663458, type: 3}
-  m_Color: {r: 0.69411767, g: 0.6117647, b: 0.8509804, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.4, y: 0.4}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1368485749
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1368485747}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.89459205, y: -4.9661603, z: 0.106325634}
-  m_LocalScale: {x: 2, y: 2, z: 2}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2141316966}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1394561669
 GameObject:
   m_ObjectHideFlags: 0
@@ -1536,90 +1371,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1801811597}
   m_CullTransparentMesh: 1
---- !u!1 &2038127566
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2038127568}
-  - component: {fileID: 2038127567}
-  m_Layer: 0
-  m_Name: Speed Up Power Up
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &2038127567
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2038127566}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 37616095ebf53744c950962f33663458, type: 3}
-  m_Color: {r: 1, g: 0.4117647, b: 0.38039216, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.4, y: 0.4}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &2038127568
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2038127566}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2.3145921, y: -4.9661603, z: 0.106325634}
-  m_LocalScale: {x: 2, y: 2, z: 2}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2141316966}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2108998307
 GameObject:
   m_ObjectHideFlags: 0
@@ -1735,13 +1486,14 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2141316966}
+  - component: {fileID: 2141316967}
   m_Layer: 0
   m_Name: PowerUps
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2141316966
 Transform:
   m_ObjectHideFlags: 0
@@ -1751,15 +1503,34 @@ Transform:
   m_GameObject: {fileID: 2141316965}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.735408, y: 4.9661603, z: -0.106325634}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1368485749}
-  - {fileID: 335436970}
-  - {fileID: 2038127568}
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2141316967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2141316965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c70f56bc5d57f944b1daa3af16e8662, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minSpawnInterval: 3
+  maxSpawnInterval: 6
+  powerUpLifetime: 10
+  powerUps:
+  - powerUpType: 0
+    powerUpPrefab: {fileID: 4869955432590448250, guid: 0ab97b6903bcf274abd8ad26238878f2, type: 3}
+  - powerUpType: 1
+    powerUpPrefab: {fileID: 8424945900358878291, guid: b428e9028a177b142857e4d148c97891, type: 3}
+  - powerUpType: 2
+    powerUpPrefab: {fileID: 4562044704465877926, guid: b6dd36ad51e5bfe49aafd9181c699b0a, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Co-Op-Snake-2D/Assets/Scripts/FoodManager.cs
+++ b/Co-Op-Snake-2D/Assets/Scripts/FoodManager.cs
@@ -17,7 +17,6 @@ public class FoodManager : MonoBehaviour
     public float minSpawnInterval = 3f;
     public float maxSpawnInterval = 6f;
     public float foodLifetime = 10f;
-    public int minSnakeLengthForMassBurner = 2; // Minimum length required to spawn Mass Burner food.
     public Food[] foods; // Array of food configurations.
 
     private void Awake()

--- a/Co-Op-Snake-2D/Assets/Scripts/PowerUpManager.cs
+++ b/Co-Op-Snake-2D/Assets/Scripts/PowerUpManager.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PowerUpManager : MonoBehaviour
+{
+    private static PowerUpManager instance;
+    public static PowerUpManager Instance { get { return instance; } } // Singleton instance accessor.
+
+    private Camera mainCamera;
+    private int viewportWidth;
+    private int viewportHeight;
+
+    public float minSpawnInterval = 3f;
+    public float maxSpawnInterval = 6f;
+    public float powerUpLifetime = 10f;
+    public PowerUp[] powerUps; // Array of powerUps configurations.
+
+    private void Awake()
+    {
+        // Ensure only one instance of PowerUpManager exists.
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject); // Prevent destruction on load.
+        }
+        else
+        {
+            Destroy(gameObject); // Destroy duplicate.
+        }
+    }
+
+    private void Start()
+    {
+        // Get the camera's viewport bounds
+        mainCamera = Camera.main;
+        viewportWidth = (int)(mainCamera.aspect * mainCamera.orthographicSize * 2f);
+        viewportHeight = (int)(mainCamera.orthographicSize * 2f);
+        Invoke("SpawnPowerUp", UnityEngine.Random.Range(minSpawnInterval, maxSpawnInterval));
+    }
+
+    private GameObject GetPowerUpPrefab(PowerUpType powerUpType)
+    {
+        // Find and return the Prefab corresponding to a PowerUpType.
+        PowerUp powerUp = Array.Find(powerUps, item => item.powerUpType == powerUpType);
+        if (powerUp != null)
+        {
+            return powerUp.powerUpPrefab; // Return Prefab if found.
+        }
+        else
+        {
+            return null; // Return null if no Prefab found.
+        }
+    }
+    public PowerUpType GetPowerUpType(string powerUpPrefabName)
+    {
+        powerUpPrefabName = powerUpPrefabName.Replace("(Clone)", "");
+        // Find and return the PowerUpType corresponding to a PowerUpPrefab.
+        PowerUp powerUp = Array.Find(powerUps, item => item.powerUpPrefab.name == powerUpPrefabName);
+        if (powerUp != null)
+        {
+            return powerUp.powerUpType; // Return PowerUpType if found.
+        }
+        else
+        {
+            return PowerUpType.NoPowerUp; // Return NoPowerUp if no PowerUpType found.
+        }
+    }
+    private void SpawnPowerUp()
+    {
+        PowerUpType powerUpType;
+        float randomValue = UnityEngine.Random.value;
+        if (randomValue <= 0.33f)
+        {
+            powerUpType = PowerUpType.ScoreBoostPowerUp;
+        }
+        else if (randomValue <= 0.66f)
+        {
+            powerUpType = PowerUpType.ShieldPowerUp;
+        }
+        else
+        {
+            powerUpType = PowerUpType.SpeedUpPowerUp;
+        }
+
+        Vector2 spawnPosition = new Vector2(UnityEngine.Random.Range(-viewportWidth / 2f, viewportWidth / 2f),
+                                            UnityEngine.Random.Range(-viewportHeight / 2f, viewportHeight / 2f));
+        GameObject powerUpPrefab = GetPowerUpPrefab(powerUpType);
+
+        if (powerUpPrefab != null)
+        {
+            GameObject powerUp = Instantiate(powerUpPrefab, spawnPosition, Quaternion.identity, this.transform);
+            Destroy(powerUp, powerUpLifetime); // Destroy powerUp after a certain time if not eaten
+        }
+
+        // Schedule the next PowerUp spawn
+        Invoke("SpawnPowerUp", UnityEngine.Random.Range(minSpawnInterval, maxSpawnInterval));
+    }
+}
+
+[System.Serializable]
+public class PowerUp
+{
+    public PowerUpType powerUpType; // Defines the type of Power Up.
+    public GameObject powerUpPrefab; // Holds the prefab associated with the Power Up type.
+}
+
+public enum PowerUpType
+{
+    ScoreBoostPowerUp,
+    ShieldPowerUp,
+    SpeedUpPowerUp,
+    NoPowerUp
+}

--- a/Co-Op-Snake-2D/Assets/Scripts/PowerUpManager.cs.meta
+++ b/Co-Op-Snake-2D/Assets/Scripts/PowerUpManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c70f56bc5d57f944b1daa3af16e8662
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Co-Op-Snake-2D/Assets/Scripts/SnakeCollisionController.cs
+++ b/Co-Op-Snake-2D/Assets/Scripts/SnakeCollisionController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class SnakeCollisionController : MonoBehaviour
 {
     private LayerMask collisionLayer; // This will be fetched from the parent object
-    SnakeController snakeController;
+    private SnakeController snakeController;
     private void Start()
     {
         snakeController = GetComponentInParent<SnakeController>();
@@ -22,7 +22,7 @@ public class SnakeCollisionController : MonoBehaviour
     {
         int collisionLayerIndex = (int)Mathf.Log(collisionLayer.value, 2);
         // Check for self-collision using layers and tags
-        if (collider2D.gameObject.layer == collisionLayerIndex)
+        if (collider2D.gameObject.layer == collisionLayerIndex && snakeController.isShieldPowerUpActive == false)
         {
             // Check if the application is running in the Unity Editor.
             #if UNITY_EDITOR
@@ -46,6 +46,23 @@ public class SnakeCollisionController : MonoBehaviour
             {
                 snakeController.ReduceBodySegment(FoodManager.Instance.GetFoodAffectedLength(foodType));
                 snakeController.DecreaseScore(FoodManager.Instance.GetFoodAffectedScore(foodType));
+            }
+            Destroy(collider2D.gameObject);
+        }
+        else if (LayerMask.LayerToName(collider2D.gameObject.layer) == "PowerUp")
+        {
+            PowerUpType powerUpType = PowerUpManager.Instance.GetPowerUpType(collider2D.gameObject.name);
+            if (powerUpType == PowerUpType.ScoreBoostPowerUp)
+            {
+                StartCoroutine(snakeController.ActivateScoreBoostPowerUp());
+            }
+            else if (powerUpType == PowerUpType.ShieldPowerUp)
+            {
+                StartCoroutine(snakeController.ActivateShieldPowerUp());
+            }
+            else if (powerUpType == PowerUpType.SpeedUpPowerUp)
+            {
+                StartCoroutine(snakeController.ActivateSpeedUpPowerUp());
             }
             Destroy(collider2D.gameObject);
         }

--- a/Co-Op-Snake-2D/Assets/Scripts/SnakeController.cs
+++ b/Co-Op-Snake-2D/Assets/Scripts/SnakeController.cs
@@ -10,6 +10,13 @@ public class SnakeController : MonoBehaviour
     public int initialBodySize = 1; // Initial number of body segments
     public float speed = 1f; // Speed of the snake
     public float moveStep = 1f; // The distance the snake moves each step
+    public float powerUpCoolDownTimer; // The cooldown Timer of powerup
+    public int scoreBoostPowerUpRatio = 1; // The ratio by which Score will increase on Score Boost PowerUp
+
+    [HideInInspector]
+    public bool isShieldPowerUpActive = false; // The flag which denotes shield state on Shield PowerUp
+
+    public float speedUpPowerUpRatio = 1.0f; // The increment ratio by which Speed will increase on Speed Up PowerUp
     public Camera mainCamera; // Reference to the main camera
     public GameObject snakeHeadPrefab; // Object for the snake head Prefab
     public GameObject snakeBodyPrefab; // Object for the snake body Prefab
@@ -23,6 +30,8 @@ public class SnakeController : MonoBehaviour
 
     public TextMeshProUGUI scoreText;
     private int score = 0;
+    private int currentScoreBoostRatio = 1;
+    
 
     private void Awake()
     {
@@ -147,23 +156,45 @@ public class SnakeController : MonoBehaviour
 
         segment.position = mainCamera.ViewportToWorldPoint(screenPosition);
     }
+    public IEnumerator ActivateScoreBoostPowerUp()
+    {
+        currentScoreBoostRatio = scoreBoostPowerUpRatio;
+        yield return new WaitForSeconds(powerUpCoolDownTimer);
+        currentScoreBoostRatio = 1;
+    }
+    public IEnumerator ActivateShieldPowerUp()
+    {
+        isShieldPowerUpActive = true;
+        yield return new WaitForSeconds(powerUpCoolDownTimer);
+        isShieldPowerUpActive = false;
+    }
+    public IEnumerator ActivateSpeedUpPowerUp()
+    {
+        speed *= speedUpPowerUpRatio;
+        yield return new WaitForSeconds(powerUpCoolDownTimer);
+        speed /= speedUpPowerUpRatio;
+    }
+    
     public int GetSnakeBodyLength()
     {
         return snakeSegments.Count - 1;
     }
     public void IncreaseScore(int incrementScore)
     {
-        score += incrementScore;
+        score += incrementScore * currentScoreBoostRatio;
         RefreshUI();
     }
     public void DecreaseScore(int decrementScore)
     {
-        score -= decrementScore;
-        if (score < 0)
+        if (isShieldPowerUpActive == false)
         {
-            score = 0;
+            score -= decrementScore;
+            if (score < 0)
+            {
+                score = 0;
+            }
+            RefreshUI();
         }
-        RefreshUI();
     }
     private void RefreshUI()
     {

--- a/Co-Op-Snake-2D/ProjectSettings/TagManager.asset
+++ b/Co-Op-Snake-2D/ProjectSettings/TagManager.asset
@@ -12,7 +12,7 @@ TagManager:
   - Water
   - UI
   - Food
-  - 
+  - PowerUp
   - 
   - 
   - 


### PR DESCRIPTION
Implemented 3 Power-Ups Spawning with Dynamic Cool Down (3 seconds by default) 
1. Shield → The snake will not die or score will not reduce when the shield is active. 
2. Score Boost → Snake will gain dynamic(2x by default) Score Points for each mass-gainer food. 
3. Speed Up → Snake should increase the speed dynamic(2x by default) after collecting this power-up.